### PR TITLE
chore: make realtime safe + expose more API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,8 @@ byteorder = "1.4.3"
 lazy_static = "1.4.0"
 generational-arena = "0.2.8"
 
-log = "0.4.14"
+# PATCH(hiroshi): disabled since it allocates on audio thread
+log = { version = "0.4.14", features = ["max_level_off"] }
 
 num-traits = "0.2"
 num-derive = "0.3.3"

--- a/soundfont-rs/src/error.rs
+++ b/soundfont-rs/src/error.rs
@@ -5,6 +5,8 @@ use riff::Chunk;
 
 #[derive(Debug)]
 pub enum ParseError {
+    OtherError(String),
+    IOError(std::io::Error),
     StringError(Utf8Error),
     NumSliceError(TryFromSliceError),
 
@@ -34,5 +36,11 @@ impl From<Utf8Error> for ParseError {
 impl From<TryFromSliceError> for ParseError {
     fn from(err: TryFromSliceError) -> Self {
         Self::NumSliceError(err)
+    }
+}
+
+impl From<std::io::Error> for ParseError {
+    fn from(err: std::io::Error) -> Self {
+        Self::IOError(err)
     }
 }

--- a/src/core/synth/font_bank.rs
+++ b/src/core/synth/font_bank.rs
@@ -18,6 +18,12 @@ impl FontBank {
         }
     }
 
+    pub fn reset(&mut self) {
+        self.fonts = TypedArena::new();
+        self.stack = Vec::new();
+        self.bank_offsets = BankOffsets::default();
+    }
+
     pub fn add_font(&mut self, font: SoundFont) -> TypedIndex<SoundFont> {
         let id = self.fonts.insert(font);
 

--- a/src/core/synth/internal/midi.rs
+++ b/src/core/synth/internal/midi.rs
@@ -1,5 +1,3 @@
-use std::convert::TryInto;
-
 use crate::core::chorus::Chorus;
 use crate::core::error::OxiError;
 use crate::core::reverb::Reverb;
@@ -68,8 +66,7 @@ fn inner_noteon(
     let preset = &channel.preset().unwrap();
 
     // list for 'sorting' preset modulators
-    let mod_list_new: Vec<Option<&Mod>> = (0..64).into_iter().map(|_| None).collect();
-    let mut mod_list: [Option<&Mod>; 64] = mod_list_new.try_into().unwrap();
+    let mut mod_list: [Option<&Mod>; 64] = [None; 64];
 
     let mut global_preset_zone = preset.global_zone();
 

--- a/src/core/synth/soundfont.rs
+++ b/src/core/synth/soundfont.rs
@@ -17,7 +17,8 @@ pub(crate) use {
 pub use preset::Preset;
 
 pub struct SoundFont {
-    presets: Vec<Arc<Preset>>,
+    // PATCH(hiroshi): allow simple enumeration of all presets
+    pub presets: Vec<Arc<Preset>>,
 }
 
 impl SoundFont {

--- a/src/core/synth/soundfont.rs
+++ b/src/core/synth/soundfont.rs
@@ -16,6 +16,7 @@ pub(crate) use {
 
 pub use preset::Preset;
 
+#[derive(Clone)]
 pub struct SoundFont {
     // PATCH(hiroshi): allow simple enumeration of all presets
     pub presets: Vec<Arc<Preset>>,

--- a/src/core/synth/voice_pool.rs
+++ b/src/core/synth/voice_pool.rs
@@ -21,7 +21,7 @@ pub struct VoicePool {
 impl VoicePool {
     pub fn new(len: usize, sample_rate: f32) -> Self {
         Self {
-            voices: Vec::new(),
+            voices: Vec::with_capacity(len), // PATCH(hiroshi): avoid heap allocation on `push` (TODO: better to use Vec<Option<Voice>> for explicit preallocation)
             sample_rate,
             polyphony_limit: len,
 


### PR DESCRIPTION
- required by https://github.com/hi-ogawa/nih-plug-examples/pull/6

Small patches for https://github.com/hi-ogawa/nih-plug-examples/pull/6

- [x] realtime safe (e.g. no allocation on `Synth::send_event`)
  - currently it fails `assert_no_alloc` in `process` callback https://github.com/Windfisch/rust-assert-no-alloc
- [x] enumerate presets from sound font
- [x] handle error for invalid soundfont file